### PR TITLE
fix FPSProblemImport bug

### DIFF
--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -676,6 +676,8 @@ class FPSProblemImport(CSRFExemptAPIView):
             with tempfile.NamedTemporaryFile("wb") as tf:
                 for chunk in file.chunks(4096):
                     tf.file.write(chunk)
+                tf.file.flush()                         #确保file写入tf成功
+                os.fsync(tf.file)                       #确保file写入tf成功
                 problems = FPSParser(tf.name).parse()
         else:
             return self.error("Parse upload file error")

--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -676,8 +676,8 @@ class FPSProblemImport(CSRFExemptAPIView):
             with tempfile.NamedTemporaryFile("wb") as tf:
                 for chunk in file.chunks(4096):
                     tf.file.write(chunk)
-                tf.file.flush()                         #确保file写入tf成功
-                os.fsync(tf.file)                       #确保file写入tf成功
+                tf.file.flush()
+                os.fsync(tf.file)
                 problems = FPSParser(tf.name).parse()
         else:
             return self.error("Parse upload file error")

--- a/problem/views/admin.py
+++ b/problem/views/admin.py
@@ -676,8 +676,10 @@ class FPSProblemImport(CSRFExemptAPIView):
             with tempfile.NamedTemporaryFile("wb") as tf:
                 for chunk in file.chunks(4096):
                     tf.file.write(chunk)
+                
                 tf.file.flush()
                 os.fsync(tf.file)
+                
                 problems = FPSParser(tf.name).parse()
         else:
             return self.error("Parse upload file error")


### PR DESCRIPTION
FPSProblemImport bug
bug：某些fps.xml题目在写入tf时还没写入成功，xml parser就已经通过tf.name读取文件，读取为空文本文件然后导致解析失败，报server error错误。
解决方案：添加tf.file.flush()        os.fsync(tf.file) 确保tf文件被成功写入      