### PR TITLE
封榜后管理员看榜逻辑修改

### DIFF
--- a/contest/views/oj.py
+++ b/contest/views/oj.py
@@ -132,7 +132,7 @@ class ContestRankAPI(APIView):
         else:
             serializer = ACMContestRankSerializer
 
-        if force_refresh == "1" and is_contest_admin:
+        if is_contest_admin:
             qs = self.get_rank()
         else:
             cache_key = f"{CacheKey.contest_rank_cache}:{self.contest.id}"


### PR DESCRIPTION
现有的ACM赛制下，封榜后比赛管理员需要打开强制更新和自动刷新才能看到实时榜单，一旦比赛结束后，无法使用自动刷新功能，管理员也拿不到实时的榜单，为赛后排名造成麻烦。所以简单的修改封榜后的逻辑为比赛管理员可以随时获取到实时榜单(似乎以前的强制刷新本就没什么意义？)。