### PR TITLE
refactor:邮件库切换django.core.mail以支持自建smtp

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -5,7 +5,6 @@ Django==2.1.7
 django-redis==4.10.0
 djangorestframework==3.8.2
 entrypoints==0.3
-Envelopes==0.4
 flake8==3.7.7
 flake8-coding==1.3.1
 flake8-quotes==1.0.0


### PR DESCRIPTION
邮件库切换django.core.mail来支持自建smtp的邮件服务