### PR TITLE
移除无效的参数

### DIFF
--- a/deploy/supervisord.conf
+++ b/deploy/supervisord.conf
@@ -39,7 +39,7 @@ stopwaitsecs = 5
 killasgroup=true
 
 [program:dramatiq]
-command=python3 manage.py rundramatiq --no-reload --processes %(ENV_MAX_WORKER_NUM)s --threads 4
+command=python3 manage.py rundramatiq --processes %(ENV_MAX_WORKER_NUM)s --threads 4
 directory=/app/
 user=nobody
 stdout_logfile=/data/log/dramatiq.log


### PR DESCRIPTION
https://github.com/Bogdanp/django_dramatiq/commit/9842fbb2312687e45e5780c3132c905fb14128f2

--no-reload 参数已经在 0.8.0 中被移除，在依赖更新时没有更新对应的参数用法，导致最新的代码无法正常进行代码评测