### PR TITLE
Fix rundramatiq and add important docs

### DIFF
--- a/deploy/supervisord.conf
+++ b/deploy/supervisord.conf
@@ -39,7 +39,7 @@ stopwaitsecs = 5
 killasgroup=true
 
 [program:dramatiq]
-command=python3 manage.py rundramatiq --no-reload --processes %(ENV_MAX_WORKER_NUM)s --threads 4
+command=python3 manage.py rundramatiq --processes %(ENV_MAX_WORKER_NUM)s --threads 4
 directory=/app/
 user=nobody
 stdout_logfile=/data/log/dramatiq.log

--- a/docs/data.json
+++ b/docs/data.json
@@ -5,6 +5,7 @@
       "level": "Important",
       "title": "2021-11-20",
       "details": [
+        "<span style=\"color:  red;\">升级 django-dramatiq 至 0.10.0，解决数据库连接无法释放的问题</span>",
         "django2.x即将停止支持，更新django到3.x LTS，相应地更新了全部相关依赖",
         "合并底包版本到python3.8-alpine3.14，为移除python2做准备",
         "按上游包的生产环境规范，修改依赖psycopg2_binary为psycopg2",

--- a/oj/dev_settings.py
+++ b/oj/dev_settings.py
@@ -1,22 +1,23 @@
 # coding=utf-8
 import os
+from utils.shortcuts import get_env
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'HOST': '127.0.0.1',
-        'PORT': 5435,
-        'NAME': "onlinejudge",
-        'USER': "onlinejudge",
-        'PASSWORD': 'onlinejudge'
+        'HOST': get_env('POSTGRES_HOST', '127.0.0.1'),
+        'PORT': get_env('POSTGRES_PORT', '5435'),
+        'NAME': get_env('POSTGRES_DB', 'onlinejudge'),
+        'USER': get_env('POSTGRES_USER', 'onlinejudge'),
+        'PASSWORD': get_env('POSTGRES_PASSWORD', 'onlinejudge')
     }
 }
 
 REDIS_CONF = {
-    "host": "127.0.0.1",
-    "port": "6380"
+    'host': get_env('REDIS_HOST', '127.0.0.1'),
+    'port': get_env('REDIS_PORT', '6380')
 }
 
 


### PR DESCRIPTION
## Bugs

- `django_dramatiq` 的 `--no-reload` 参数已废弃，默认不再自动重启，此参数直接导致项目启动失败
  - https://github.com/QingdaoU/OnlineJudge/pull/412
  - https://github.com/QingdaoU/OnlineJudge/pull/392
- `django_dramatiq` 已修复数据库连接释放的 bug，本 PR 仅完善更新日志，提醒用户升级
  - https://github.com/Bogdanp/django_dramatiq/issues/19
  - https://github.com/QingdaoU/OnlineJudge/pull/392
- 【尚未修复】请记得发版，目前日志虽已更新，但 docker image 仍是旧版
  - https://github.com/QingdaoU/OnlineJudge/pull/392

### 【升级前】数据库连接无法释放

![image](https://user-images.githubusercontent.com/26411634/167290231-2e330a7a-7079-449b-9e65-6eedb36b5151.png)

![image](https://user-images.githubusercontent.com/26411634/167290221-78236879-3c38-4956-a2eb-dee3d96d03b9.png)


### 【升级后】数据库连接正常释放

![image](https://user-images.githubusercontent.com/26411634/167290250-de827cfa-f64c-4a79-9985-a75243b7fba0.png)


## Enhancements

- `oj/dev_settings.py`: 本地开发时支持环境变量，便于使用 `docker-compose` 来开发
