### PR TITLE
feat(config): submission not show to all only apply to non-admin users

### DIFF
--- a/submission/views/oj.py
+++ b/submission/views/oj.py
@@ -143,7 +143,10 @@ class SubmissionListAPI(APIView):
             except Problem.DoesNotExist:
                 return self.error("Problem doesn't exist")
             submissions = submissions.filter(problem=problem)
-        if (myself and myself == "1") or not SysOptions.submission_list_show_all:
+        if not SysOptions.submission_list_show_all:
+            if request.user.is_anonymous or not request.user.is_admin_role():
+                submissions = submissions.filter(user_id=request.user.id)
+        if myself and myself == "1":
             submissions = submissions.filter(user_id=request.user.id)
         elif username:
             submissions = submissions.filter(username__icontains=username)


### PR DESCRIPTION
原项目中，管理后台的系统设置，如果把submission show to all设置为关闭，则即使管理员查看提交列表也只能看到自己的提交记录。

该PR在判断为非公开展示列表的情况下，同时检查当前用户是否为管理员，再进行过滤。