### PR TITLE
fix(sec): upgrade Django to 4.0.6

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2019.3.9
 chardet==3.0.4
 coverage==6.1.2
-Django==3.2.9
+Django==4.2.3
 django-redis==5.0.0
 djangorestframework==3.12.4
 entrypoints==0.3


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in Django 3.2.9
- [CVE-2022-34265](https://www.oscs1024.com/hd/CVE-2022-34265)


### What did I do？
Upgrade Django from 3.2.9 to 4.0.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS