### PR TITLE
Found a typo

### DIFF
--- a/submission/views/oj.py
+++ b/submission/views/oj.py
@@ -70,7 +70,7 @@ class SubmissionAPI(APIView):
         except Problem.DoesNotExist:
             return self.error("Problem not exist")
         if data["language"] not in problem.languages:
-            return self.error(f"{data['language']} is now allowed in the problem")
+            return self.error(f"{data['language']} is not allowed in the problem")
         submission = Submission.objects.create(user_id=request.user.id,
                                                username=request.user.username,
                                                language=data["language"],


### PR DESCRIPTION
submission/views/oj.py, at line 73.

```diff
         if data["language"] not in problem.languages:
-            return self.error(f"{data['language']} is now allowed in the problem")
+            return self.error(f"{data['language']} is not allowed in the problem")
```

1 word changed: (now → not)